### PR TITLE
coercing GStrings into Strings in support of a fix for issue 28.

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/clover/GenerateCoverageReportTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/clover/GenerateCoverageReportTask.groovy
@@ -58,15 +58,15 @@ class GenerateCoverageReportTask extends CloverReportTask {
         String cloverReportDir = "${getReportsDir()}/clover"
 
         if(getXml()) {
-            writeReport("$cloverReportDir/clover.xml", ReportType.XML.format)
+            writeReport("$cloverReportDir/clover.xml" as String, ReportType.XML.format)
         }
 
         if(getJson()) {
-            writeReport("$cloverReportDir/json", ReportType.JSON.format)
+            writeReport("$cloverReportDir/json" as String, ReportType.JSON.format)
         }
 
         if(getHtml()) {
-            writeReport("$cloverReportDir/html", ReportType.HTML.format)
+            writeReport("$cloverReportDir/html" as String, ReportType.HTML.format)
         }
 
         if(getPdf()) {


### PR DESCRIPTION
Alternatively, the declared argument types of could be writeReport(def outfile, String type), though I feel this is more explicit and potentially less prone to error.

I'm puzzled why this is a problem at all...
