### PR TITLE
Invoke javac with debug parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The snapshot file should survive clean builds, so it should *not* be placed in t
 location is `.clover/coverage.db.snapshot`.
 * `includeTasks`: A list of task names, allows to explicitly specify which test tasks should be introspected and used to gather coverage information - useful if there are more than one `Test` tasks in a project.
 * `excludeTasks`: A list of task names, allows to exclude test tasks from introspection and gathering coverage information - useful if there are more than one `Test` tasks in a project.
-* `debug`: Controls whether to invoke javac with the -g flag. This is useful for Spring MVC code that uses debugging symbols for parameter mapping. (defaults to `false`).
 
 Within `clover` you can define [coverage contexts](http://confluence.atlassian.com/display/CLOVER/Using+Coverage+Contexts)
 in a closure named `contexts`. There are two types of coverage contexts: statement contexts and method contexts. You can
@@ -93,6 +92,7 @@ need to be carried over to the compilation of the instrumented sources.  These a
 
 * `encoding`: The (optional) encoding name.  If not provided, the platform default according to the JVM will be used. See [java.nio.charset.StandardCharsets](http://docs.oracle.com/javase/8/docs/api/java/nio/charset/StandardCharsets.html) for a full list of charsets.
 * `executable`: The (optional) javac executable to use, should be an absolute file.
+* `debug`: Controls whether to invoke javac with the -g flag. This is useful for Spring MVC code that uses debugging symbols for parameter mapping. (defaults to `false`).
 
 The Clover plugin defines the following convention properties in the `clover` closure:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The snapshot file should survive clean builds, so it should *not* be placed in t
 location is `.clover/coverage.db.snapshot`.
 * `includeTasks`: A list of task names, allows to explicitly specify which test tasks should be introspected and used to gather coverage information - useful if there are more than one `Test` tasks in a project.
 * `excludeTasks`: A list of task names, allows to exclude test tasks from introspection and gathering coverage information - useful if there are more than one `Test` tasks in a project.
+* `debug`: Controls whether to invoke javac with the -g flag. This is useful for Spring MVC code that uses debugging symbols for parameter mapping. (defaults to `false`).
 
 Within `clover` you can define [coverage contexts](http://confluence.atlassian.com/display/CLOVER/Using+Coverage+Contexts)
 in a closure named `contexts`. There are two types of coverage contexts: statement contexts and method contexts. You can

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
@@ -23,4 +23,5 @@ package com.bmuschko.gradle.clover
 class CloverCompilerConvention {
     String encoding = 'UTF-8'
     File executable
+    boolean debug = false
 }

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -158,7 +158,7 @@ class CloverPlugin implements Plugin<Project> {
         instrumentCodeAction.conventionMapping.map('methodContexts') { cloverPluginConvention.contexts.methods }
         instrumentCodeAction.conventionMapping.map('executable') { cloverPluginConvention.compiler.executable?.absolutePath }
         instrumentCodeAction.conventionMapping.map('encoding') { cloverPluginConvention.compiler.encoding }
-        instrumentCodeAction.conventionMapping.map('debug') { cloverPluginConvention.debug }
+        instrumentCodeAction.conventionMapping.map('debug') { cloverPluginConvention.compiler.debug }
         instrumentCodeAction
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -158,6 +158,7 @@ class CloverPlugin implements Plugin<Project> {
         instrumentCodeAction.conventionMapping.map('methodContexts') { cloverPluginConvention.contexts.methods }
         instrumentCodeAction.conventionMapping.map('executable') { cloverPluginConvention.compiler.executable?.absolutePath }
         instrumentCodeAction.conventionMapping.map('encoding') { cloverPluginConvention.compiler.encoding }
+        instrumentCodeAction.conventionMapping.map('debug') { cloverPluginConvention.debug }
         instrumentCodeAction
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -41,7 +41,6 @@ class CloverPluginConvention {
     CloverCompilerConvention compiler = new CloverCompilerConvention()
     List<String> includeTasks
     List<String> excludeTasks
-    boolean debug = false
 
     def clover(Closure closure) {
         ConfigureUtil.configure(closure, this)

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -41,6 +41,7 @@ class CloverPluginConvention {
     CloverCompilerConvention compiler = new CloverCompilerConvention()
     List<String> includeTasks
     List<String> excludeTasks
+    boolean debug = false
 
     def clover(Closure closure) {
         ConfigureUtil.configure(closure, this)

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -53,6 +53,7 @@ class InstrumentCodeAction implements Action<Task> {
     List<String> testIncludes
     def statementContexts
     def methodContexts
+    boolean debug
 
     @Override
     void execute(Task task) {
@@ -235,7 +236,7 @@ class InstrumentCodeAction implements Action<Task> {
             }
 
             ant.javac(source: getSourceCompatibility(), target: getTargetCompatibility(), encoding: getEncoding(),
-                      executable: getExecutable())
+                      executable: getExecutable(), debug: getDebug())
         }
     }
 
@@ -249,7 +250,7 @@ class InstrumentCodeAction implements Action<Task> {
      */
     private void compileJava(AntBuilder ant, Set<File> srcDirs, File destDir, String classpath) {
         ant.javac(destdir: destDir.canonicalPath, source: getSourceCompatibility(), target: getTargetCompatibility(),
-                  classpath: classpath, encoding: getEncoding(), executable: getExecutable()) {
+                  classpath: classpath, encoding: getEncoding(), executable: getExecutable(), debug: getDebug()) {
             srcDirs.each { srcDir ->
                 src(path: srcDir)
             }


### PR DESCRIPTION
This adds a parameter to the compiler options to invoke javac with the debug flag. This is to fix issues my team is having with Clover and Spring MVC code.

I would like to write a test for this, but I'm struggling with it and am hoping for some guidance. My plan for testing this is to add an integration test that invokes the plugin with the debug flag set to true and then assert using ASM to read the bytecode and verify that debugging info is present. The part I'm having trouble with is that the plugin restores the original classes, which means that after the plugin has completed running I don't have access to the instrumented classes in my test. Is there some way to turn off the restore for a test? Or perhaps, capture the instrumented classes before the restore occurs?
