### PR TITLE
Minor changes to support clover in our environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ need to be carried over to the compilation of the instrumented sources.  These a
 
 * `encoding`: The (optional) encoding name.  If not provided, the platform default according to the JVM will be used. See [java.nio.charset.StandardCharsets](http://docs.oracle.com/javase/8/docs/api/java/nio/charset/StandardCharsets.html) for a full list of charsets.
 * `executable`: The (optional) javac executable to use, should be an absolute file.
+* `debug`: If true, passes the -g flag to javac when compiling, if false (default), uses the default flags.
 
 The Clover plugin defines the following convention properties in the `clover` closure:
 

--- a/src/integTest/groovy/com/bmuschko/gradle/clover/CloverPluginIntegSpec.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/clover/CloverPluginIntegSpec.groovy
@@ -227,6 +227,19 @@ class CloverPluginIntegSpec extends Specification {
         'except test'   | 'exclude' | '0'                 | '1'
     }
 
+    def "Aggregate databases without first running instrument task properly configures license"() {
+        given: "a Java project, with a generated report"
+        projectName = 'java-project'
+        runTasks('clean', 'cloverGenerateReport')
+        getReportsDir().createNewFile()
+
+        when: "the Clover aggregate databases task is run"
+        runTasks('cloverAggregateDatabases')
+
+        then: "an exception is not thrown"
+        true
+    }
+
     private File getProjectDir() {
         new File('src/integTest/projects', projectName)
     }

--- a/src/main/groovy/com/bmuschko/gradle/clover/AggregateDatabasesTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/AggregateDatabasesTask.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 
@@ -20,6 +21,12 @@ class AggregateDatabasesTask extends DefaultTask {
     @Input
     String initString
 
+    /**
+     * Mandatory Clover license file.
+     */
+    @InputFile
+    File licenseFile
+
     List<Task> testTasks = new ArrayList<Task>()
 
     void aggregate(Task testTask) {
@@ -34,6 +41,7 @@ class AggregateDatabasesTask extends DefaultTask {
 
         if(existsAtLeastOneCloverDbFile(cloverDbFiles)) {
             ant.taskdef(resource: 'cloverlib.xml', classpath: getCloverClasspath().asPath)
+            ant.property(name: 'clover.license.path', value: getLicenseFile().canonicalPath)
 
             ant.'clover-merge'(initString: aggregationFile.canonicalPath) {
                 cloverDbFiles.each { cloverDbFile ->

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
@@ -23,4 +23,5 @@ package com.bmuschko.gradle.clover
 class CloverCompilerConvention {
     String encoding = 'UTF-8'
     File executable
+    Boolean debug = false
 }

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -67,6 +67,7 @@ class CloverPlugin implements Plugin<Project> {
             conventionMapping.with {
                 map('initString') { getInitString(cloverPluginConvention) }
                 map('cloverClasspath') { project.configurations.getByName(CONFIGURATION_NAME).asFileTree }
+                map('licenseFile') { getLicenseFile(project, cloverPluginConvention) }
             }
         }
 
@@ -158,6 +159,7 @@ class CloverPlugin implements Plugin<Project> {
         instrumentCodeAction.conventionMapping.map('methodContexts') { cloverPluginConvention.contexts.methods }
         instrumentCodeAction.conventionMapping.map('executable') { cloverPluginConvention.compiler.executable?.absolutePath }
         instrumentCodeAction.conventionMapping.map('encoding') { cloverPluginConvention.compiler.encoding }
+        instrumentCodeAction.conventionMapping.map('compileWithDebug') { cloverPluginConvention.compiler.debug }
         instrumentCodeAction
     }
 
@@ -206,11 +208,13 @@ class CloverPlugin implements Plugin<Project> {
      * @param task Task
      */
     private void setCloverReportConventionMappings(Project project, CloverPluginConvention cloverPluginConvention, Task task) {
-        task.conventionMapping.map('reportsDir') { new File(project.buildDir, 'reports') }
+        def reportDir = new File(project.buildDir, 'reports')
+        task.conventionMapping.map('reportsDir') { reportDir }
         task.conventionMapping.map('xml') { cloverPluginConvention.report.xml }
         task.conventionMapping.map('json') { cloverPluginConvention.report.json }
         task.conventionMapping.map('html') { cloverPluginConvention.report.html }
         task.conventionMapping.map('pdf') { cloverPluginConvention.report.pdf }
+        task.outputs.dir(new File(reportDir, 'clover'))
     }
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -51,6 +51,7 @@ class InstrumentCodeAction implements Action<Task> {
     List<String> includes
     List<String> excludes
     List<String> testIncludes
+    Boolean compileWithDebug
     def statementContexts
     def methodContexts
 
@@ -249,7 +250,7 @@ class InstrumentCodeAction implements Action<Task> {
      */
     private void compileJava(AntBuilder ant, Set<File> srcDirs, File destDir, String classpath) {
         ant.javac(destdir: destDir.canonicalPath, source: getSourceCompatibility(), target: getTargetCompatibility(),
-                  classpath: classpath, encoding: getEncoding(), executable: getExecutable()) {
+                  classpath: classpath, encoding: getEncoding(), executable: getExecutable(), debug: getCompileWithDebug()) {
             srcDirs.each { srcDir ->
                 src(path: srcDir)
             }


### PR DESCRIPTION
(1) Allow instrument with full debug symbols.
(2) Set license path in cloverAggregateDatabases task.  Previously, the task would fail if the instrument step was up-to-date.
(3) Mark $buildDir/reports/clover as an output of the cloverGenerateReport task.  Previously, reports were not generated after a clean build when the reports directory was created by some other task.
