### PR TITLE
Fix for issue #66: License issues in multi-project config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.jfrog.bintray'
 //apply plugin: 'clover'
 
 group = 'com.bmuschko'
-version = '2.0.1'
+version = '2.0.2'
 defaultTasks 'clean', 'build'
 
 sourceSets {

--- a/src/integTest/groovy/com/bmuschko/gradle/clover/CloverPluginIntegSpec.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/clover/CloverPluginIntegSpec.groovy
@@ -57,6 +57,19 @@ class CloverPluginIntegSpec extends Specification {
 
         and: "the Clover snapshot is not generated because test optimization is not enabled"
         cloverSnapshot.exists() == false
+
+        when: "the Clover report generation task is run a second time without cleaning but the reports deleted"
+        cloverXmlReport.delete()
+        cloverHtmlReport.delete()
+        cloverJsonReport.delete()
+        cloverPdfReport.delete()
+        runTasks('cloverGenerateReport')
+
+        then: "the Clover reports are generated again"
+        cloverXmlReport.exists()
+        cloverHtmlReport.exists()
+        cloverJsonReport.exists()
+        cloverPdfReport.exists()
     }
 
     def "Build a Java project with disabled instrumentation"() {

--- a/src/main/groovy/com/bmuschko/gradle/clover/AggregateDatabasesTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/AggregateDatabasesTask.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 
@@ -20,6 +21,12 @@ class AggregateDatabasesTask extends DefaultTask {
     @Input
     String initString
 
+    /**
+     * Mandatory Clover license file.
+     */
+    @InputFile
+    File licenseFile
+
     List<Task> testTasks = new ArrayList<Task>()
 
     void aggregate(Task testTask) {
@@ -34,6 +41,7 @@ class AggregateDatabasesTask extends DefaultTask {
 
         if(existsAtLeastOneCloverDbFile(cloverDbFiles)) {
             ant.taskdef(resource: 'cloverlib.xml', classpath: getCloverClasspath().asPath)
+            ant.property(name: 'clover.license.path', value: getLicenseFile().canonicalPath)
 
             ant.'clover-merge'(initString: aggregationFile.canonicalPath) {
                 cloverDbFiles.each { cloverDbFile ->

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -66,6 +66,7 @@ class CloverPlugin implements Plugin<Project> {
         project.tasks.withType(AggregateDatabasesTask) {
             conventionMapping.with {
                 map('initString') { getInitString(cloverPluginConvention) }
+                map('licenseFile') { getLicenseFile(project, cloverPluginConvention) }
                 map('cloverClasspath') { project.configurations.getByName(CONFIGURATION_NAME).asFileTree }
             }
         }


### PR DESCRIPTION
The AggregateDatabasesTask was not seeding the clover.license.path
property in the Ant builder and would fail if executed in a build
where no other clover tasks participated.
