### PR TITLE
Add instrumentLambda setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The snapshot file should survive clean builds, so it should *not* be placed in t
 location is `.clover/coverage.db.snapshot`.
 * `includeTasks`: A list of task names, allows to explicitly specify which test tasks should be introspected and used to gather coverage information - useful if there are more than one `Test` tasks in a project.
 * `excludeTasks`: A list of task names, allows to exclude test tasks from introspection and gathering coverage information - useful if there are more than one `Test` tasks in a project.
+* `instrumentLambda`: Controls which lambda types to instrument. [Expression lambdas may cause instrumentation to crash](https://confluence.atlassian.com/cloverkb/java-8-code-instrumented-by-clover-fails-to-compile-442270815.html).
 
 Within `clover` you can define [coverage contexts](http://confluence.atlassian.com/display/CLOVER/Using+Coverage+Contexts)
 in a closure named `contexts`. There are two types of coverage contexts: statement contexts and method contexts. You can

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -158,6 +158,7 @@ class CloverPlugin implements Plugin<Project> {
         instrumentCodeAction.conventionMapping.map('methodContexts') { cloverPluginConvention.contexts.methods }
         instrumentCodeAction.conventionMapping.map('executable') { cloverPluginConvention.compiler.executable?.absolutePath }
         instrumentCodeAction.conventionMapping.map('encoding') { cloverPluginConvention.compiler.encoding }
+        instrumentCodeAction.conventionMapping.map('instrumentLambda') { cloverPluginConvention.instrumentLambda }
         instrumentCodeAction
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -41,6 +41,7 @@ class CloverPluginConvention {
     CloverCompilerConvention compiler = new CloverCompilerConvention()
     List<String> includeTasks
     List<String> excludeTasks
+    String instrumentLambda
 
     def clover(Closure closure) {
         ConfigureUtil.configure(closure, this)

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -51,6 +51,7 @@ class InstrumentCodeAction implements Action<Task> {
     List<String> includes
     List<String> excludes
     List<String> testIncludes
+    String instrumentLambda
     def statementContexts
     def methodContexts
 
@@ -125,6 +126,10 @@ class InstrumentCodeAction implements Action<Task> {
 
         if(!getEnabled()) {
             attributes['enabled'] = false
+        }
+
+        if(getInstrumentLambda()) {
+            attributes['instrumentLambda'] = getInstrumentLambda()
         }
 
         attributes


### PR DESCRIPTION
Fixes #62.

In the absence of a value, none is set, thus preserving whatever the default is your version of clover.
