### PR TITLE
Add ability to exclude certain test patterns via testExcludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ to `'**/*.java'` and `'**/*.groovy'` for Groovy projects).
 * `testIncludes`: A list of String Ant Glob Patterns to include for instrumentation for
 [per-test coverage](http://confluence.atlassian.com/display/CLOVER/Unit+Test+Results+and+Per-Test+Coverage) (defaults to
 `'**/*Test.java'` for Java projects, defaults to `'**/*Test.java'` and `'**/*Test.groovy'` for Groovy projects).
+* `testExcludes`: A list of String Ant Glob Patterns to exclude from instrumentation for
+[per-test coverage](http://confluence.atlassian.com/display/CLOVER/Unit+Test+Results+and+Per-Test+Coverage) (for example mock classes, defaults to
+empty list - no excludes).
 * `additionalSourceDirs`: Defines custom source sets to be added for instrumentation e.g. `sourceSets.custom.allSource.srcDirs`.
 * `additionalTestDirs`: Defines custom test source sets to be added for instrumentation e.g. `sourceSets.integTest.allSource.srcDirs`.
 * `targetPercentage`: The required target percentage total coverage e.g. "10%". The build fails if that goals is not met.
@@ -119,6 +122,7 @@ The Clover plugin defines the following convention properties in the `clover` cl
         classesBackupDir = file("${sourceSets.main.classesDir}-backup")
         licenseLocation = 'clover-license.txt'
         excludes = ['**/SynchronizedMultiValueMap.java']
+        testExcludes = ['**/Mock*.java']
         targetPercentage = '85%'
 
         contexts {

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -154,6 +154,7 @@ class CloverPlugin implements Plugin<Project> {
         instrumentCodeAction.conventionMapping.map('includes') { getIncludes(project, cloverPluginConvention) }
         instrumentCodeAction.conventionMapping.map('excludes') { cloverPluginConvention.excludes }
         instrumentCodeAction.conventionMapping.map('testIncludes') { getTestIncludes(project, cloverPluginConvention) }
+        instrumentCodeAction.conventionMapping.map('testExcludes') { getTestExcludes(project, cloverPluginConvention) }
         instrumentCodeAction.conventionMapping.map('statementContexts') { cloverPluginConvention.contexts.statements }
         instrumentCodeAction.conventionMapping.map('methodContexts') { cloverPluginConvention.contexts.methods }
         instrumentCodeAction.conventionMapping.map('executable') { cloverPluginConvention.compiler.executable?.absolutePath }
@@ -400,6 +401,21 @@ class CloverPlugin implements Plugin<Project> {
         }
 
         [DEFAULT_JAVA_TEST_INCLUDES]
+    }
+
+    /**
+     * Gets test patterns excluded from instrumentation. The default is empty list - no excludes.
+     *
+     * @param project Project
+     * @param cloverPluginConvention Clover plugin convention
+     * @return Test excludes
+     */
+    private List getTestExcludes(Project project, CloverPluginConvention cloverPluginConvention) {
+        if(cloverPluginConvention.testExcludes) {
+            return cloverPluginConvention.testExcludes
+        }
+
+        []
     }
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -36,6 +36,7 @@ class CloverPluginConvention {
     List<String> includes
     List<String> excludes
     List<String> testIncludes
+    List<String> testExcludes
     CloverReportConvention report = new CloverReportConvention()
     CloverContextsConvention contexts = new CloverContextsConvention()
     CloverCompilerConvention compiler = new CloverCompilerConvention()

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -51,6 +51,7 @@ class InstrumentCodeAction implements Action<Task> {
     List<String> includes
     List<String> excludes
     List<String> testIncludes
+    List<String> testExcludes
     def statementContexts
     def methodContexts
 
@@ -85,6 +86,10 @@ class InstrumentCodeAction implements Action<Task> {
                     ant.fileset(dir: testSrcDir) {
                         getTestIncludes().each { include ->
                             ant.include(name: include)
+                        }
+
+                        getTestExcludes().each { exclude ->
+                            ant.exclude(name: exclude)
                         }
                     }
                 }


### PR DESCRIPTION
This allows to exclude non-critical classes from coverage report - for example mocks, that typically get 0 coverage and lower the average result
