### PR TITLE
Support additional test sourceSets.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -127,7 +127,7 @@ class CloverPlugin implements Plugin<Project> {
         optimizeTestSetAction.conventionMapping.map('snapshotFile') { getSnapshotFile(project, cloverPluginConvention, false, testTask) }
         optimizeTestSetAction.conventionMapping.map('licenseFile') { getLicenseFile(project, cloverPluginConvention) }
         optimizeTestSetAction.conventionMapping.map('cloverClasspath') { project.configurations.getByName(CONFIGURATION_NAME).asFileTree }
-        optimizeTestSetAction.conventionMapping.map('testSrcDirs') { getTestSourceDirectories(project, cloverPluginConvention, testTask) }
+        optimizeTestSetAction.conventionMapping.map('testSourceSets') { getTestSourceSets(project, cloverPluginConvention) }
         optimizeTestSetAction.conventionMapping.map('buildDir') { project.buildDir }
         optimizeTestSetAction
     }

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -31,8 +31,8 @@ class CloverPluginConvention {
     String targetPercentage
     boolean optimizeTests
     String snapshotFile
-    Set<File> additionalSourceDirs
-    Set<File> additionalTestDirs
+    List<CloverSourceSet> additionalSourceSets = []
+    List<CloverSourceSet> additionalTestSourceSets =[]
     List<String> includes
     List<String> excludes
     List<String> testIncludes
@@ -63,6 +63,22 @@ class CloverPluginConvention {
         CloverContextConvention methodContext = new CloverContextConvention()
         closure.delegate = methodContext
         contexts.methods << methodContext
+        closure()
+    }
+
+    def additionalSourceSet(Closure closure) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        CloverSourceSet additionalSourceSet = new CloverSourceSet()
+        closure.delegate = additionalSourceSet
+        additionalSourceSets << additionalSourceSet
+        closure()
+    }
+
+    def additionalTestSourceSet(Closure closure) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        CloverSourceSet additionalTestSourceSet = new CloverSourceSet()
+        closure.delegate = additionalTestSourceSet
+        additionalTestSourceSets << additionalTestSourceSet
         closure()
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverSourceSet.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverSourceSet.groovy
@@ -1,0 +1,17 @@
+package com.bmuschko.gradle.clover
+
+class CloverSourceSet implements Serializable {
+    static final long serialVersionUID = 7526472295622776147L
+    def srcDirs = [] as Set<File>
+    File classesDir
+    File backupDir
+
+    @Override
+    String toString() {
+        "CloverSourceSet{" +
+        "srcDirs=" + srcDirs +
+        ", classesDir=" + classesDir +
+        ", backupDir=" + backupDir +
+        '}'
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverSourceSetUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverSourceSetUtils.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.clover
+
+import com.bmuschko.gradle.clover.CloverSourceSet
+
+/**
+ * Clover source set utilities.
+ *
+ * @author Benjamin Muschko
+ */
+final class CloverSourceSetUtils {
+    private CloverSourceSetUtils() {}
+
+    static List<File> getSourceDirs(Set<CloverSourceSet> sourceSets) {
+        def srcDirs = []
+
+        sourceSets.each { sourceSet ->
+            srcDirs.addAll(sourceSet.srcDirs)
+        }
+
+        srcDirs
+    }
+
+    static boolean existsDirectory(File dir) {
+        dir && dir.exists()
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/clover/OptimizeTestSetAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/OptimizeTestSetAction.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
@@ -41,7 +42,7 @@ class OptimizeTestSetAction implements Action<Task>, Spec<FileTreeElement> {
     @InputFile File licenseFile
     @Optional @InputFile File snapshotFile
     @InputDirectory File buildDir
-    Set<File> testSrcDirs
+    @Input Set<CloverSourceSet> testSourceSets
     Set<String> includes
 
     @Override
@@ -57,8 +58,9 @@ class OptimizeTestSetAction implements Action<Task>, Spec<FileTreeElement> {
             ant.taskdef(resource: 'cloverjunitlib.xml', classpath: getCloverClasspath().asPath)
             ant.property(name: 'clover.license.path', value: getLicenseFile().canonicalPath)
             ant.property(name: 'clover.initstring', value: "${getBuildDir()}/${getInitString()}")
+            List<File> testSrcDirs = CloverSourceSetUtils.getSourceDirs(getTestSourceSets())
             def testset = ant."clover-optimized-testset"(snapshotFile: getSnapshotFile(), debug: true) {
-                getTestSrcDirs().each { testSrcDir ->
+                testSrcDirs.each { testSrcDir ->
                     ant.fileset(dir: testSrcDir)
                 }
             }

--- a/src/main/groovy/com/bmuschko/gradle/clover/RestoreOriginalClassesAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/RestoreOriginalClassesAction.groovy
@@ -4,22 +4,42 @@ import org.gradle.api.Action
 import org.gradle.api.Task
 
 class RestoreOriginalClassesAction implements Action<Task> {
-    File classesDir
-    File testClassesDir
-    File classesBackupDir
-    File testClassesBackupDir
+    Set<CloverSourceSet> sourceSets
+    Set<CloverSourceSet> testSourceSets
 
 
     @Override
     void execute(Task t) {
         def ant = new AntBuilder()
-        ant.delete(includeEmptyDirs: true) {
-            fileset(dir: getClassesDir().canonicalPath, includes: '**/*')
-        }
-        ant.delete(includeEmptyDirs: true) {
-            fileset(dir: getTestClassesDir().canonicalPath, includes: '**/*')
-        }
-        ant.move(file: getClassesBackupDir().canonicalPath, tofile: getClassesDir().canonicalPath, failonerror: true)
-        ant.move(file: getTestClassesBackupDir().canonicalPath, tofile: getTestClassesDir().canonicalPath, failonerror: false)
+
+        deleteAllClassesDirectories(ant, getSourceSets())
+        deleteAllClassesDirectories(ant, getTestSourceSets())
+        moveAllBackupDirsToClassesDirs(ant, getSourceSets())
+        moveAllBackupDirsToClassesDirs(ant, getTestSourceSets())
     }
+
+    private void deleteAllClassesDirectories(AntBuilder ant, Set<CloverSourceSet> sourceSets) {
+        for(CloverSourceSet sourceSet : sourceSets) {
+            deleteClassesDirectory(ant, sourceSet.classesDir)
+         }
+    }
+
+    private void deleteClassesDirectory(AntBuilder ant, File classesDir) {
+         ant.delete(includeEmptyDirs: true) {
+            fileset(dir: classesDir.canonicalPath, includes: '**/*')
+        }
+    }
+
+    private void moveAllBackupDirsToClassesDirs(AntBuilder ant, Set<CloverSourceSet> sourceSets) {
+        for(CloverSourceSet sourceSet : sourceSets) {
+            moveBackupToClassesDir(ant, sourceSet.backupDir, sourceSet.classesDir)
+        }
+    }
+
+    private void moveBackupToClassesDir(AntBuilder ant, File backupDir, File classesDir) {
+        if(CloverSourceSetUtils.existsDirectory(backupDir)) {
+            ant.move(file: backupDir.canonicalPath, tofile: classesDir.canonicalPath, failonerror: true)
+         }
+    }
+
 }


### PR DESCRIPTION
Fix for https://github.com/bmuschko/gradle-clover-plugin/issues/11
Merged branch
https://github.com/bmuschko/gradle-clover-plugin/tree/refactoring into
trunk and finished implementation.
Example build.gradle stanza:
clover {
    additionalTestSourceSets << [
        srcDirs: sourceSets.integration.allSource.srcDirs,
        classesDir: sourceSets.integration.output.classesDir
    ]
}