### PR TITLE
Fix Issue #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ location is `.clover/coverage.db.snapshot`.
 * `excludeTasks`: A list of task names, allows to exclude test tasks from introspection and gathering coverage information - useful if there are more than one `Test` tasks in a project.
 * `instrumentLambda`: Controls which lambda types to instrument. [Expression lambdas may cause instrumentation to crash](https://confluence.atlassian.com/cloverkb/java-8-code-instrumented-by-clover-fails-to-compile-442270815.html).
 * `useClover3`: Controls the selection of the Clover 3 compatible Ant task resource file when the Clover dependency does not have a versioned artifact. Normally the correct value is determined by inspecting the version of the dependency artifact.
+* `flushpolicy`: This String attribute controls how Clover flushes coverage data during a test run. Valid values are directed, interval, or threaded. [clover-setup Parameters](https://confluence.atlassian.com/clover/clover-setup-71600085.html#clover-setup-parametersParameters)
+* `flushinterval`: When the flushpolicy is set to interval or threaded this value is the minimum period between flush operations (in milliseconds). [clover-setup Parameters](https://confluence.atlassian.com/clover/clover-setup-71600085.html#clover-setup-parametersParameters)
 
 Within `clover` you can define [coverage contexts](http://confluence.atlassian.com/display/CLOVER/Using+Coverage+Contexts)
 in a closure named `contexts`. There are two types of coverage contexts: statement contexts and method contexts. You can
@@ -201,6 +203,11 @@ The Clover plugin defines the following convention properties in the `clover` cl
             testResultsInclude = 'TEST-*.xml'
         }
     }
+
+## Project Properties
+
+The Clover plugin uses the following properties:
+* `-PcloverInstrumentedJar`: This property can be used to prepare a JAR or EAR for distributed code coverage. When using this property the instrumented classes are left in the `classes` directory so that the `jar` tasks will bundle them. The property causes the `jar` tasks to execute after the `test` tasks to ensure that the Clover instrumentation has happened. This property should be used with a separate test execution in a Continuous Integration environment because the JAR files will be created with Clover instrumented code which cannot be used in a production environment.
 
 ## FAQ
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 ### Version 2.1.1 (TDB)
 
+New feature
+* Generate Clover instrumented JAR files
+See the documentation in [README.md](README.md) for the new usage.
+
+
+* Fix Generate JARs with instrumened classes - [Issue 33](https://github.com/bmuschko/gradle-clover-plugin/issues/33)
 * Fix `licenseLocation` is enforced even when using OpenClover - [Issue 85](https://github.com/bmuschko/gradle-clover-plugin/issues/85)
 
 ### Version 2.1.0 (May 13, 2017)

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.bmuschko'
-version = '2.1.0'
+version = '2.1.1'
 defaultTasks 'clean', 'build'
 
 sourceSets {
@@ -47,6 +47,7 @@ repositories {
 dependencies {
     compile localGroovy()
     compile gradleApi()
+    testCompile 'commons-io:commons-io:2.5'
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'
     }

--- a/src/integTest/projects/java-multi-project-with-ear/build.gradle
+++ b/src/integTest/projects/java-multi-project-with-ear/build.gradle
@@ -1,0 +1,57 @@
+import com.bmuschko.gradle.clover.CloverPlugin
+
+buildscript {
+    dependencies {
+        classpath files('../../../../build/classes/main')
+    }
+}
+
+apply from: '../deps.gradle'
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+
+    apply plugin: CloverPlugin
+
+    dependencies {
+        clover deps.clover
+    }
+
+    clover {
+        // Set the flush policy parameters for testing with a deployed application
+        flushinterval = 100
+        flushpolicy = 'threaded'
+
+        report {
+            json = true
+            html = true
+            pdf = true
+        }
+    }
+}
+
+project(':projectCar') {
+    apply plugin: 'java'
+    dependencies {
+        testCompile deps.junit
+    }
+}
+
+project(':projectDriver') {
+    apply plugin: 'java'
+    dependencies {
+        compile project(':projectCar')
+        testCompile deps.junit
+    }
+}
+
+project(':projectEar') {
+    apply plugin: 'ear'
+
+    dependencies {
+        deploy project(':projectDriver')
+        earlib project(':projectCar')
+    }
+}

--- a/src/integTest/projects/java-multi-project-with-ear/projectCar/src/main/java/Car.java
+++ b/src/integTest/projects/java-multi-project-with-ear/projectCar/src/main/java/Car.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class Car {
+
+    // tested
+    public boolean start() {
+        return true;
+    }
+
+    // untested
+    public boolean stop() {
+        return false;
+    }
+}

--- a/src/integTest/projects/java-multi-project-with-ear/projectCar/src/test/java/CarTest.java
+++ b/src/integTest/projects/java-multi-project-with-ear/projectCar/src/test/java/CarTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.Test;
+
+public class CarTest {
+
+    @Test
+    public void testStart() {
+        new Car().start();
+    }
+
+}

--- a/src/integTest/projects/java-multi-project-with-ear/projectDriver/src/main/java/Driver.java
+++ b/src/integTest/projects/java-multi-project-with-ear/projectDriver/src/main/java/Driver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class Driver {
+
+    private Car car;
+
+    public Driver(Car car) {
+        this.car = car;
+    }
+
+    // tested
+    public boolean start() {
+        return car.start();
+    }
+
+    // untested
+    public boolean stop() {
+        return car.stop();
+    }
+}

--- a/src/integTest/projects/java-multi-project-with-ear/projectDriver/src/test/java/DriverTest.java
+++ b/src/integTest/projects/java-multi-project-with-ear/projectDriver/src/test/java/DriverTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.Test;
+
+public class DriverTest {
+
+    @Test
+    public void testStart() {
+        new Driver(new Car()).start();
+    }
+
+}

--- a/src/integTest/projects/java-multi-project-with-ear/settings.gradle
+++ b/src/integTest/projects/java-multi-project-with-ear/settings.gradle
@@ -1,0 +1,2 @@
+include 'projectCar', 'projectDriver', 'projectEar'
+

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPluginConvention.groovy
@@ -45,6 +45,8 @@ class CloverPluginConvention {
     List<String> excludeTasks
     String instrumentLambda
     boolean debug = false
+    int flushinterval = 1000
+    FlushPolicy flushpolicy = FlushPolicy.directed
 
     def clover(Closure closure) {
         ConfigureUtil.configure(closure, this)

--- a/src/main/groovy/com/bmuschko/gradle/clover/FlushPolicy.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/FlushPolicy.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.clover
+
+/**
+ * Supported Clover flushpolicy types
+ *
+ * @author Alex Volanis
+ */
+public enum FlushPolicy {
+    directed,
+    interval,
+    threaded
+
+    static List getAllPolicies() {
+        values().collect { it.name }
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -53,6 +53,8 @@ class InstrumentCodeAction implements Action<Task> {
     def statementContexts
     def methodContexts
     boolean debug
+    int flushinterval
+    String flushpolicy
 
     @Override
     void execute(Task task) {
@@ -189,6 +191,9 @@ class InstrumentCodeAction implements Action<Task> {
             attributes['instrumentLambda'] = getInstrumentLambda()
         }
 
+        attributes.flushinterval = getFlushinterval()
+        attributes.flushpolicy = getFlushpolicy()
+
         attributes
     }
 
@@ -316,6 +321,7 @@ class InstrumentCodeAction implements Action<Task> {
             ant.javac(source: getSourceCompatibility(), target: getTargetCompatibility(), encoding: getEncoding(),
                       debug: getDebug())
             }
+            addMarkerFile(destDir)
         }
     }
 
@@ -335,7 +341,16 @@ class InstrumentCodeAction implements Action<Task> {
                     src(path: srcDir)
                 }
             }
+            addMarkerFile(destDir)
         }
+    }
+
+    /**
+     * Adds a marker file to the destination directory.
+     */
+    private void addMarkerFile(File destDir) {
+        File marker = new File(destDir, "clover.instrumented")
+        marker << "the classes in this directory are instrumented with clover"
     }
 
 }

--- a/src/test/groovy/com/bmuschko/gradle/clover/CloverPluginConventionSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/clover/CloverPluginConventionSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.clover
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CloverPluginConventionSpec extends Specification {
+    def "FlushPolicy assignment conversion works"() {
+        given: "A new CloverPluginConvention instance"
+        def convention = new CloverPluginConvention()
+
+        when: "and configuration closure with a valid flushpolicy and flushinterval"
+        convention.clover {
+            flushinterval = 500
+            flushpolicy = 'threaded'
+        }
+
+        then: "then flushpolicy and flushinterval are assigned correctly"
+        convention.flushinterval == 500
+        convention.flushpolicy == FlushPolicy.threaded
+    }
+
+    def "Invalid FlushPolicy assignment fails as expected"() {
+        given: "A new CloverPluginConvention instance"
+        def convention = new CloverPluginConvention()
+
+        when: "and configuration closure with a bad flushpolicy"
+        convention.clover {
+            flushpolicy = 'bogus'
+        }
+
+        then: "then right exception is thrown"
+        def e = thrown(org.gradle.internal.typeconversion.TypeConversionException)
+        e.message =~ /^Cannot convert string value 'bogus' to an enum value/
+    }
+}

--- a/src/test/groovy/com/bmuschko/gradle/clover/FlushPolicySpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/clover/FlushPolicySpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.clover
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class FlushPolicySpec extends Specification {
+    @Unroll
+    def "Convert String policy (#stringName) to Enum type (#enumType)"() {
+        given: "A valid String policy name"
+
+        when: "The name is converted"
+        FlushPolicy policy = FlushPolicy.valueOf(stringName)
+
+        then: "The type matches the expected value"
+        enumType == policy
+
+        where:
+        stringName | enumType
+        'directed' | FlushPolicy.directed
+        'interval' | FlushPolicy.interval
+        'threaded' | FlushPolicy.threaded
+    }
+
+    def "Invalid flush policy String name fails to convert"() {
+        given: "An invalid String policy name"
+        String invalid = 'bogus'
+
+        when: "when the conversion is attempted"
+        FlushPolicy.valueOf(invalid)
+
+        then: "then right exception is thrown"
+        def e = thrown(IllegalArgumentException)
+        'No enum constant com.bmuschko.gradle.clover.FlushPolicy.bogus' == e.message
+    }
+}


### PR DESCRIPTION
Introduce a new project property to control creating of instrumented
JAR files. Also added the flushinterval and flushpolicy convention
properties to support controlling the instrumentation when used with
a deployed WAR/EAR.

Potential enhancement: Use Gretty to make a complete demonstration
in a full Spring Boot integration test with clover coverage coming
from the Gretty integration test.