### PR TITLE
Fix #128 Additional compiler option to control the groovy compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ need to be carried over to the compilation of the instrumented sources.  These a
 * `executable`: The (optional) javac executable to use, should be an absolute file.
 * `debug`: Controls whether to invoke javac with the -g flag. This is useful for Spring MVC code that uses reflection for parameter mapping. (defaults to `false`).
 * `additionalArgs`: The (optional) additional command line arguments for the compiler. This is useful for Spring MVC code that uses reflection for parameter mapping. This should be valid command line arguments as a spaces separated string. No attempt is made to validate this line, it is passed verbatim to the <compilerarg> nested element for the Ant `javac` task.
+* `additionalGroovycOpts`: The (optional) additional options for the `groovyc` compiler. See [http://groovy-lang.org/groovyc.html#_ant_task]
 
 The Clover plugin defines the following convention properties in the `clover` closure:
 
@@ -212,6 +213,7 @@ The Clover plugin defines the following convention properties in the `clover` cl
             // used to add debug information for Spring applications
             debug = true
             additionalArgs = '-parameters'
+            additionalGroovycOpts = [configscript: 'myConfigScript.groovy']
         }
 
         contexts {

--- a/src/functTest/groovy/com/bmuschko/gradle/clover/GroovyProjectCompileConfigSpec.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/clover/GroovyProjectCompileConfigSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.bmuschko.gradle.clover
 
+import org.gradle.testkit.runner.BuildResult
 import spock.lang.Unroll
 
 class GroovyProjectCompileConfigSpec extends AbstractFunctionalTestBase {
@@ -26,7 +27,7 @@ class GroovyProjectCompileConfigSpec extends AbstractFunctionalTestBase {
         gradleVersion = gradle
 
         when: "the Clover report generation task is run"
-        build('clean', 'cloverGenerateReport')
+        BuildResult result = build('clean', 'cloverGenerateReport', '--info')
 
         then: "the Clover coverage database is generated"
         cloverDb.exists()
@@ -46,6 +47,12 @@ class GroovyProjectCompileConfigSpec extends AbstractFunctionalTestBase {
 
         and: "the Clover snapshot is not generated because test optimization is not enabled"
         cloverSnapshot.exists() == false
+
+        and: "that the gradle output contains the two files compiled by groovyc"
+        with(result.output) {
+            contains('Book.groovy')
+            contains('BookGroovyTest.groovy')
+        }
 
         where:
         gradle << GRADLE_TEST_VERSIONS

--- a/src/functTest/projects/groovy-project-compile-config/build.gradle
+++ b/src/functTest/projects/groovy-project-compile-config/build.gradle
@@ -27,6 +27,7 @@ tasks.withType(GroovyCompile) {
 clover {
     compiler {
         encoding = 'UTF-8'
+        additionalGroovycOpts = [listfiles: 'yes']
     }
 
     report {

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverCompilerConvention.groovy
@@ -25,4 +25,5 @@ class CloverCompilerConvention {
     File executable
     boolean debug = false
     String additionalArgs = null
+    Map additionalGroovycOpts = null
 }

--- a/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/CloverPlugin.groovy
@@ -193,6 +193,7 @@ class CloverPlugin implements Plugin<Project> {
             map('flushinterval') { cloverPluginConvention.flushinterval }
             map('flushpolicy') { cloverPluginConvention.flushpolicy.name() }
             map('additionalArgs') { cloverPluginConvention.compiler.additionalArgs }
+            map('additionalGroovycOpts') { cloverPluginConvention.compiler.additionalGroovycOpts }
         }
         instrumentCodeAction
     }

--- a/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/clover/InstrumentCodeAction.groovy
@@ -55,7 +55,7 @@ class InstrumentCodeAction implements Action<Task> {
     int flushinterval
     String flushpolicy
     String additionalArgs
-
+    Map additionalGroovycOpts
     @Override
     void execute(Task task) {
         instrumentCode(task)
@@ -310,7 +310,8 @@ class InstrumentCodeAction implements Action<Task> {
     private void compileGroovyAndJava(AntBuilder ant, Collection<File> srcDirs, File destDir, String classpath) {
         if (srcDirs.size() > 0) {
             String args = getAdditionalArgs()
-            ant.groovyc(destdir: destDir.canonicalPath, classpath: classpath, encoding: getEncoding()) {
+            Map groovycAttrs = [destdir: destDir.canonicalPath, classpath: classpath, encoding: getEncoding()] + (getAdditionalGroovycOpts() ?: [:])
+            ant.groovyc(groovycAttrs) {
                 srcDirs.each { srcDir ->
                     src(path: srcDir)
                 }


### PR DESCRIPTION
Add option to pass arguments to the `groovyc` compiler