### PR TITLE
Configure build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ jdk:
 jobs:
   include:
     - stage: all tests
-      script: GRADLE_OPTS=-Dfile.encoding=windows-1252 ./gradlew clean build --stacktrace --no-daemon
+      script: GRADLE_OPTS=-Dfile.encoding=windows-1252 ./gradlew clean build --stacktrace --no-daemon --scan
     - stage: release
       script: skip
       deploy:
         provider: script
-        script: ./gradlew --stacktrace clean assemble bintrayUpload gitPublishPush -Dorg.ajoberstar.grgit.auth.username=bmuschko -Dorg.ajoberstar.grgit.auth.password=$GH_TOKEN
+        script: ./gradlew --stacktrace clean assemble bintrayUpload gitPublishPush -Dorg.ajoberstar.grgit.auth.username=bmuschko -Dorg.ajoberstar.grgit.auth.password=$GH_TOKEN --scan
         on:
           tags: true
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'
@@ -7,6 +8,11 @@ plugins {
     id "com.jfrog.bintray" version "1.8.4"
     id 'org.ajoberstar.reckon' version '0.9.0'
     id 'org.ajoberstar.git-publish' version '2.0.0'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 gradlePlugin {


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.