### PR TITLE
Use reckon settings plugin for new release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'eclipse'
-    id 'org.ajoberstar.reckon' version '0.18.3'
     id 'org.ajoberstar.git-publish' version '4.2.2'
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,7 +1,1 @@
-
-reckon {
-  scopeFromProp()
-  stageFromProp('milestone', 'rc', 'final')
-}
-
 reckonTagCreate.dependsOn check

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ pluginManagement {
 
 plugins {
     id "com.gradle.develocity" version "3.18"
+    id('org.ajoberstar.reckon.settings') version '0.18.3'
 }
 
 develocity {
@@ -25,6 +26,15 @@ develocity {
         }
     }
 }
+plugins {
+  <version>'
+}
 
+reckon {
+  defaultInferredScope = 'patch'
+  stages 'rc', 'final'
+  scopeCalc = calcScopeFromProp().or(calcScopeFromCommitMessages())
+  stageCalc = calcStageFromProp()
+}
 
 rootProject.name = 'gradle-clover-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,9 +26,6 @@ develocity {
         }
     }
 }
-plugins {
-  <version>'
-}
 
 reckon {
   defaultInferredScope = 'patch'


### PR DESCRIPTION
New release exposed issue with reckon project plugin. Switched to settings plugin to avoid version order of evaluation issues.
